### PR TITLE
Was missing username for pypi.

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -51,7 +51,7 @@ function publish:test {
     # publish the package to pypi
     twine upload dist/* \
         --repository testpypi \
-        --username "$TEST_PYPI_USERNAME" \
+        --username "__token__" \
         --password "$TEST_PYPI_PASSWORD"
 }
 
@@ -60,7 +60,7 @@ function publish:prod {
     # publish the package to pypi
     twine upload dist/* \
         --repository pypi \
-        --username "$PROD_PYPI_USERNAME" \
+        --username "__token__" \
         --password "$PROD_PYPI_PASSWORD"
 }
 


### PR DESCRIPTION
while setting up this new repo I purposely kept out the username and password from any env files. I did add them as github action secrets but the 'username' is always `__token__` and is common knowledge.  Keeping that data in the script for now.