### PR TITLE
Fix run.sh script credentials as variables.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,13 +9,12 @@ mypkg = ["*.json", "*.png"]
 # python_project_00 = ["*.json", "*.png"]
 
 [project]
-name = "automating_build_process"
-version = "0.0.1"
+name = "python_project_bsahlas_00"
+version = "0.0.3"
 description = "TPP Course - Automating Build Process"
 readme = "README.md"
 requires-python = ">=3.8"
 license = "MIT"
-license-files = ["LICEN[CS]E.*"]
 keywords = ["tpp", "continuous delivery", "python"]
 authors = [
   {email = "bill.sahlas@gmail.com"},
@@ -27,17 +26,15 @@ classifiers = [
 ]
 
 dependencies = [
-    "build",
-    "numpy",
-    "pre-commit",
-    "twine"
+    "numpy"
 ]
 
 [project.optional-dependencies]
+colors = ["rich"]
 static-code-analysis = ["pre-commit"]
 test = ["pytest", "pytest-cov"]
-release = ["twine"]
-dev = ["automating_build_process[test, release, static-code-analysis]"]
+release = ["twine", "build"]
+dev = ["python_project_bsahlas_00[test, colors, release, static-code-analysis]"]
 
 [project.urls]
 repository = "https://github.com/bsahlas/automating-build-process"

--- a/run.sh
+++ b/run.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 set -e #if any line fails the entire program fails
-
+set -x #echo each line before executing it
 THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>& 1 && pwd )"
 
 function try-load-dotenv {
@@ -37,30 +37,32 @@ function help {
 
 function install {
     python -m pip install --upgrade pip
-    python -m pip install --editable "$THIS_DIR/"
+    python -m pip install --editable "${THIS_DIR}/[dev]"
 }
 
 function build {
     python -m pip install --upgrade pip
     python -m pip install build
-    python -m build --sdist --wheel  "$THIS_DIR/"
+    python -m pip install twine
+    python -m build --sdist --wheel  "${THIS_DIR}/"
 }
 
 function publish:test {
     try-load-dotenv || true
     # publish the package to pypi
-    twine upload dist/ \
+    twine upload dist/* \
+        --verbose \
         --repository testpypi \
-        --username "__token__" \
+        --username __token__ \
         --password "$TEST_PYPI_PASSWORD"
 }
 
 function publish:prod {
     try-load-dotenv || true
     # publish the package to pypi
-    twine upload dist/ \
+    twine upload dist/* \
         --repository pypi \
-        --username "__token__" \
+        --username __token__ \
         --password "$PROD_PYPI_PASSWORD"
 }
 


### PR DESCRIPTION
more script edits.  The problem had to do with how the credentials were being set through global env vars.  I _think_ it was '"' quotation marks that were causing the fails if I understood the logs.