### PR TITLE
Fix step that calls run.sh build.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -75,7 +75,7 @@ jobs:
       run: chmod +x ./run.sh
     - name: Build
       run: |
-        /bin/bash -x ./run.sh build
+        /bin/bash -x run.sh build
     - name: Ensure ./dist is not empty
       run: |
         if [ ! -d ./dist ] || [ -z "$(ls -A ./dist)" ]; then


### PR DESCRIPTION
more script error fix attempts.  The script when deployed on the build running as part of the Github Action workflow was not properly parsed. 